### PR TITLE
Miscellaneous features and fixes

### DIFF
--- a/GTAdhocToolchain.CodeGen/AdhocCodeGen.cs
+++ b/GTAdhocToolchain.CodeGen/AdhocCodeGen.cs
@@ -198,6 +198,8 @@ namespace GTAdhocToolchain.CodeGen
                     WriteTryCatch(instruction as InsTryCatch); break;
                 case AdhocInstructionType.UNDEF:
                     WriteUndef(instruction as InsUndef); break;
+                case AdhocInstructionType.VA_CALL:
+                    WriteVariableCall(instruction as InsVaCall); break;
                 case AdhocInstructionType.NIL_CONST:
                 case AdhocInstructionType.VOID_CONST:
                 case AdhocInstructionType.ASSIGN_POP:
@@ -216,6 +218,11 @@ namespace GTAdhocToolchain.CodeGen
                 default:
                     throw new NotImplementedException();
             }
+        }
+
+        private void WriteVariableCall(InsVaCall vaCall)
+        {
+            stream.WriteUInt32(vaCall.PopObjectCount);
         }
 
         private void WriteUndef(InsUndef undef)

--- a/GTAdhocToolchain.Compiler/CompilationMessages.cs
+++ b/GTAdhocToolchain.Compiler/CompilationMessages.cs
@@ -9,9 +9,11 @@ namespace GTAdhocToolchain.Compiler
     public class CompilationMessages
     {
         public const string Warning_UsingAwait_Code = "USING_AWAIT";
+        public const string Warning_UsingVaCall_Code = "USING_VACALL";
         public static Dictionary<string, string> Warnings = new()
         {
-            { Warning_UsingAwait_Code, "Async/Await is only usable in GT6 and above." },
+            { Warning_UsingAwait_Code, "Async/Await is only available in GT6 and above" },
+            { Warning_UsingVaCall_Code, "Variable Calls/Spread Syntax (<function>.(...<arg>) aka VA_CALL instruction) is only available in GT6 and above" },
         };
     }
 }

--- a/GTAdhocToolchain.Core/AdhocModule.cs
+++ b/GTAdhocToolchain.Core/AdhocModule.cs
@@ -16,6 +16,8 @@ namespace GTAdhocToolchain.Core
 
         public List<AdhocSymbol> DefinedMethods { get; set; } = new();
 
+        public AdhocModule ParentModule { get; set; }
+
         public bool DefineStatic(AdhocSymbol symbol)
         {
             if (DefinedStaticVariables.Contains(symbol))

--- a/GTAdhocToolchain.Core/Instructions/InsElementEval.cs
+++ b/GTAdhocToolchain.Core/Instructions/InsElementEval.cs
@@ -11,6 +11,8 @@ namespace GTAdhocToolchain.Core.Instructions
     /// </summary>
     public class InsElementEval : InstructionBase
     {
+        public readonly static InsElementEval Default = new();
+
         public override AdhocInstructionType InstructionType => AdhocInstructionType.ELEMENT_EVAL;
 
         public override string InstructionName => "ELEMENT_EVAL";

--- a/GTAdhocToolchain.Core/Instructions/InsElementPush.cs
+++ b/GTAdhocToolchain.Core/Instructions/InsElementPush.cs
@@ -11,6 +11,8 @@ namespace GTAdhocToolchain.Core.Instructions
     /// </summary>
     public class InsElementPush : InstructionBase
     {
+        public readonly static InsElementPush Default = new();
+
         public override AdhocInstructionType InstructionType => AdhocInstructionType.ELEMENT_PUSH;
 
         public override string InstructionName => "ELEMENT_PUSH";

--- a/GTAdhocToolchain.Core/Instructions/InsVaCall.cs
+++ b/GTAdhocToolchain.Core/Instructions/InsVaCall.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 
 namespace GTAdhocToolchain.Core.Instructions
 {
+    /// <summary>
+    /// Represents a function call where one argument is an array that represents all the function arguments.
+    /// </summary>
     public class InsVaCall : InstructionBase
     {
         public static readonly InsVoidConst Empty = new();
@@ -14,15 +17,18 @@ namespace GTAdhocToolchain.Core.Instructions
 
         public override string InstructionName => "VA_CALL";
 
-        public uint Value { get; set; }
+        /// <summary>
+        /// Should always be two. (function object + unique & single spread expression)
+        /// </summary>
+        public uint PopObjectCount { get; set; }
 
         public override void Deserialize(AdhocStream stream)
         {
-            Value = stream.ReadUInt32();
+            PopObjectCount = stream.ReadUInt32();
         }
 
         public override string ToString()
-            => $"{InstructionType}: Value={Value}";
+            => $"{InstructionType}: Value={PopObjectCount}";
 
     }
 }


### PR DESCRIPTION
* Added support for VA_CALL (variable arguments call)
```js
function sum(x, y, z) {
  return x + y + z;
}

varnumbers = [1, 2, 3];

sum(...numbers);
```

* Added support for Object Selector with arbitrary `->` syntax
```js
var end_load_img = method (context)
{
    image_face.FadeActor.start();
    image_face.on_delay_load_complete = nil;
};

image_face.on_delay_load_complete = *self->end_load_img; // OBJECT_SELECTOR + EVAL (*)
```

* `extends System::Object` is no longer needed for basic inheritance
```js
class MyClass
{
    // ...
}
```

* More accurate static variable resolving from parent modules (accessing a parent static variable from a nested module)
* Add compilation warning when using VA_CALL
* No longer print subroutine argument indices when disassembling 
* Breaking change: **Remove Object Selector hack**