### PR TITLE
Add GitHub Action to build VSCode extension

### DIFF
--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -1,0 +1,35 @@
+name: Build VSCode extension
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      # get npm
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 14
+
+      - name: Install npm dependencies
+        run: |
+          npm install -g vsce
+          npm install
+  
+      - name: Copy license file to make Visual Studio Code Extension Manager not cry
+        run: cp LICENSE vscode-extension/LICENSE
+
+      - name: Build package
+        run: vsce package
+        working-directory: ./vscode-extension
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: vscode-extension
+          path: vscode-extension/adhoc-*.vsix
+          if-no-files-found: error

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -16,10 +16,11 @@ jobs:
         with:
           node-version: 14
 
+      - name: Install Visual Studio Code Extension Manager
+        run: npm install -g vsce
+
       - name: Install npm dependencies
-        run: |
-          npm install -g vsce
-          npm install
+        run: npm install
   
       - name: Copy license file to make Visual Studio Code Extension Manager not cry
         run: cp LICENSE vscode-extension/LICENSE

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Install npm dependencies
         run: npm install
+        working-directory: ./vscode-extension
   
       - name: Copy license file to make Visual Studio Code Extension Manager not cry
         run: cp LICENSE vscode-extension/LICENSE

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -32,6 +32,6 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: vscode-extension
+          name: adhoc-vscode-extension
           path: vscode-extension/adhoc-*.vsix
           if-no-files-found: error


### PR DESCRIPTION
Only runs when you tell it to & saves extension as artifact - not as a release (note: gets discarded after 90 days iirc)