### PR TITLE
Add GitHub Action to build GTAdhocToolchain.exe

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
 
     - uses: actions/setup-dotnet@v2
       with:

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -1,0 +1,19 @@
+name: build toolchain
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: '6.0.x'
+        include-prerelease: true
+
+    - name: Build
+      run: dotnet build

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -17,8 +17,9 @@ jobs:
         dotnet-version: '6.0.x'
         include-prerelease: true
 
-    - name: Dotnet publish
+    - name: Dotnet publish GTAdhocToolchain.CLI
       run: dotnet publish --configuration Release
+      working-directory: ./GTAdhocToolchain.CLI
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -17,14 +17,58 @@ jobs:
         dotnet-version: '6.0.x'
         include-prerelease: true
 
-    - name: Dotnet publish GTAdhocToolchain.CLI
+    - name: Publish GTAdhocToolchain.CLI for Windows (framework dependent)
       run: dotnet publish --configuration Release
       working-directory: ./GTAdhocToolchain.CLI
+      continue-on-error: true
+
+    - name: Publish GTAdhocToolchain.CLI for Windows (self contained)
+      run: dotnet publish --configuration Release -r win-x86 -p:PublishSingleFile=true -p:PublishTrimmed=true
+      working-directory: ./GTAdhocToolchain.CLI
+      continue-on-error: true
+
+    - name: Publish GTAdhocToolchain.CLI for Linux (self contained)
+      run: dotnet publish --configuration Release -r linux-x64 -p:PublishSingleFile=true -p:PublishTrimmed=true
+      working-directory: ./GTAdhocToolchain.CLI
+      continue-on-error: true
+
+    - name: Publish GTAdhocToolchain.CLI for Mac OSX (self contained)
+      run: dotnet publish --configuration Release -r osx-x64 -p:PublishSingleFile=true -p:PublishTrimmed=true
+      working-directory: ./GTAdhocToolchain.CLI
+      continue-on-error: true
 
     - uses: actions/upload-artifact@v3
       with:
-        name: GTAdhocToolchain
+        name: GTAdhocToolchain-win-framework
         path: |
           GTAdhocToolchain.CLI/bin/Release/net6.0/publish/*
           !GTAdhocToolchain.CLI/bin/Release/net6.0/publish/*.pdb
         if-no-files-found: error
+      continue-on-error: true
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: GTAdhocToolchain-win-x86
+        path: |
+          GTAdhocToolchain.CLI/bin/Release/net6.0/win-x86/publish/*
+          !GTAdhocToolchain.CLI/bin/Release/net6.0/win-x86/publish/*.pdb
+        if-no-files-found: error
+      continue-on-error: true
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: GTAdhocToolchain-linux-x64
+        path: |
+          GTAdhocToolchain.CLI/bin/Release/net6.0/linux-x64/publish/*
+          !GTAdhocToolchain.CLI/bin/Release/net6.0/linux-x64/publish/*.pdb
+        if-no-files-found: error
+      continue-on-error: true
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: GTAdhocToolchain-osx-x64
+        path: |
+          GTAdhocToolchain.CLI/bin/Release/net6.0/osx-x64/publish/*
+          !GTAdhocToolchain.CLI/bin/Release/net6.0/osx-x64/publish/*.pdb
+        if-no-files-found: error
+      continue-on-error: true

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -17,13 +17,13 @@ jobs:
         dotnet-version: '6.0.x'
         include-prerelease: true
 
-    - name: Build
-      run: dotnet build --configuration Release
-      
+    - name: Dotnet publish
+      run: dotnet publish --configuration Release
+
     - uses: actions/upload-artifact@v3
       with:
         name: GTAdhocToolchain
         path: |
-          GTAdhocToolchain.CLI/bin/Release/net6.0/*
-          !GTAdhocToolchain.CLI/bin/Release/net6.0/*.pdb
+          GTAdhocToolchain.CLI/bin/Release/net6.0/publish/*
+          !GTAdhocToolchain.CLI/bin/Release/net6.0/publish/*.pdb
         if-no-files-found: error

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -18,12 +18,12 @@ jobs:
         include-prerelease: true
 
     - name: Build
-      run: dotnet build
+      run: dotnet build --configuration Release
       
     - uses: actions/upload-artifact@v3
       with:
         name: GTAdhocToolchain
         path: |
-          GTAdhocToolchain.CLI/bin/**/*
-          !GTAdhocToolchain.CLI/bin/**/*.pdb
+          GTAdhocToolchain.CLI/bin/Release/net6.0/*
+          !GTAdhocToolchain.CLI/bin/Release/net6.0/*.pdb
         if-no-files-found: error

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -1,4 +1,4 @@
-name: build toolchain
+name: Build GTAdhocToolchain
 
 on:
   workflow_dispatch:
@@ -19,3 +19,15 @@ jobs:
 
     - name: Build
       run: dotnet build
+      
+    - uses: actions/upload-artifact@v3
+      with:
+        name: GTAdhocToolchain
+        path: |
+          GTAdhocToolchain.CLI/bin/Release/net6.0/*.exe
+          GTAdhocToolchain.CLI/bin/Release/net6.0/*.dll
+          GTAdhocToolchain.CLI/bin/Release/net6.0/*.json
+          GTAdhocToolchain.CLI/bin/Release/net6.0/*.txt
+          GTAdhocToolchain.CLI/bin/Release/net6.0/*.config
+          GTAdhocToolchain.CLI/bin/Release/net6.0/*.xml
+          GTAdhocToolchain.CLI/bin/Release/net6.0/ref/*.dll

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -24,10 +24,6 @@ jobs:
       with:
         name: GTAdhocToolchain
         path: |
-          GTAdhocToolchain.CLI/bin/Release/net6.0/*.exe
-          GTAdhocToolchain.CLI/bin/Release/net6.0/*.dll
-          GTAdhocToolchain.CLI/bin/Release/net6.0/*.json
-          GTAdhocToolchain.CLI/bin/Release/net6.0/*.txt
-          GTAdhocToolchain.CLI/bin/Release/net6.0/*.config
-          GTAdhocToolchain.CLI/bin/Release/net6.0/*.xml
-          GTAdhocToolchain.CLI/bin/Release/net6.0/ref/*.dll
+          GTAdhocToolchain.CLI/bin/**/*
+          !GTAdhocToolchain.CLI/bin/**/*.pdb
+        if-no-files-found: error

--- a/GTAdhocToolchain.CLI/GTAdhocToolchain.CLI.csproj
+++ b/GTAdhocToolchain.CLI/GTAdhocToolchain.CLI.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <BaseOutputPath></BaseOutputPath>
-    <AssemblyName>$(SolutionName)</AssemblyName>
+    <AssemblyName>GTAdhocToolchain</AssemblyName>
     <SignAssembly>False</SignAssembly>
   </PropertyGroup>
 


### PR DESCRIPTION
Same applies as in #5 

If/when you add unit tests, add a `run: dotnet test` step before `dotnet publish ...`