### PR TITLE
Support --output when compiling project files

### DIFF
--- a/GTAdhocToolchain.CLI/Program.cs
+++ b/GTAdhocToolchain.CLI/Program.cs
@@ -269,7 +269,7 @@ namespace GTAdhocToolchain.CLI
             prj.PrintInfo();
 
             Logger.Info("Started project build.");
-            if (!prj.Build(buildVerbs.WriteExceptionsToFile))
+            if (!prj.Build(buildVerbs.WriteExceptionsToFile, buildVerbs.OutputPath))
             {
                 Logger.Error("Project build failed.");
                 Environment.ExitCode = -1;
@@ -445,7 +445,7 @@ namespace GTAdhocToolchain.CLI
         [Option('i', "input", Required = true, HelpText = "Input project file or source script.")]
         public string InputPath { get; set; }
 
-        [Option('o', "output", Required = false, HelpText = "Output compiled scripts when compiling standalone scripts (not projects).")]
+        [Option('o', "output", Required = false, HelpText = "Output compiled scripts when compiling standalone scripts or projects.")]
         public string OutputPath { get; set; }
 
         [Option('v', "version", Required = false, Default = 12, HelpText = "Adhoc compile version (for files, not projects).")]

--- a/GTAdhocToolchain.Project/AdhocProject.cs
+++ b/GTAdhocToolchain.Project/AdhocProject.cs
@@ -129,7 +129,7 @@ namespace GTAdhocToolchain.Project
         /// Builds the project.
         /// </summary>
         /// <returns></returns>
-        public bool Build(bool debug = false)
+        public bool Build(bool debug = false, string customOutputDir = "")
         {
             if (!Directory.Exists(ProjectDir))
             {
@@ -200,11 +200,13 @@ namespace GTAdhocToolchain.Project
 
                 AdhocCodeGen codeGen = new AdhocCodeGen(compiler.MainFrame, compiler.SymbolMap);
                 codeGen.Generate();
-                codeGen.SaveTo(Path.Combine(ProjectDir, OutputName + ".adc"));
+                customOutputDir = string.IsNullOrWhiteSpace(customOutputDir) ? "" : Path.GetDirectoryName(customOutputDir);
+                var outputPath = Path.Combine(string.IsNullOrWhiteSpace(customOutputDir) ? ProjectDir : customOutputDir, OutputName) + ".adc";
+                codeGen.SaveTo(outputPath);
 
                 if (MergeWidget)
                 {
-                    bool res = MergeRootWidgets(Path.ChangeExtension(Path.Combine(ProjectDir, OutputName), ".mproject"), SerializeComponents);
+                    bool res = MergeRootWidgets(Path.ChangeExtension(outputPath, ".mproject"), SerializeComponents);
                     return res;
                 }
 


### PR DESCRIPTION
If the --output option is used when compiling a project, write the output ADC / mproject file(s) into the directory specified. Unfortunately I haven't been able to build the CLI tool to test this properly, but it's written defensively to handle the user entering either a directory or a file in a directory, and handles the rare cases where Path.GetDirectoryName() can return null or empty directory paths by ignoring the --output option if it isn't valid.