### PR TITLE
Update github actions workflows to latest version

### DIFF
--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 
-    - uses: actions/setup-dotnet@v2
+    - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '6.0.x'
         include-prerelease: true
@@ -37,7 +37,7 @@ jobs:
       working-directory: ./GTAdhocToolchain.CLI
       continue-on-error: true
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: GTAdhocToolchain-win-framework
         path: |
@@ -46,7 +46,7 @@ jobs:
         if-no-files-found: error
       continue-on-error: true
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: GTAdhocToolchain-win-x86
         path: |
@@ -55,7 +55,7 @@ jobs:
         if-no-files-found: error
       continue-on-error: true
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: GTAdhocToolchain-linux-x64
         path: |
@@ -64,7 +64,7 @@ jobs:
         if-no-files-found: error
       continue-on-error: true
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: GTAdhocToolchain-osx-x64
         path: |

--- a/.github/workflows/build-toolchain.yml
+++ b/.github/workflows/build-toolchain.yml
@@ -15,7 +15,6 @@ jobs:
     - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '6.0.x'
-        include-prerelease: true
 
     - name: Publish GTAdhocToolchain.CLI for Windows (framework dependent)
       run: dotnet publish --configuration Release

--- a/.github/workflows/build-vscode-extension.yml
+++ b/.github/workflows/build-vscode-extension.yml
@@ -9,12 +9,12 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # get npm
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 14
+          node-version: 20
 
       - name: Install Visual Studio Code Extension Manager
         run: npm install -g vsce
@@ -30,7 +30,7 @@ jobs:
         run: vsce package
         working-directory: ./vscode-extension
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: adhoc-vscode-extension
           path: vscode-extension/adhoc-*.vsix


### PR DESCRIPTION
This fixes the "Build VSCode extension" workflow, and starts the "Build GTAdhocToolchain" workflow but it still gets tons of error down the line during compilation, still it's better than it was

Before:
![image](https://github.com/user-attachments/assets/cd557722-9a6a-44ce-be1a-f6ecea1c2a3f)

After:
![image](https://github.com/user-attachments/assets/cacce424-1362-4732-b3ba-c593688d07b9)

For months I was frustrated because I couldn't find the vscode extension excutable